### PR TITLE
API for plugin integrations in malysis

### DIFF
--- a/fs/filesystem.go
+++ b/fs/filesystem.go
@@ -17,6 +17,16 @@ type localFile struct {
 	isImport bool
 }
 
+type readerFile struct {
+	reader   io.Reader
+	path     string
+	name     string
+	isImport bool
+}
+
+var _ core.File = &localFile{}
+var _ core.File = &readerFile{}
+
 func (f *localFile) Name() string {
 	return f.path
 }
@@ -30,6 +40,31 @@ func (f *localFile) IsApp() bool {
 }
 
 func (f *localFile) IsImport() bool {
+	return f.isImport
+}
+
+func NewReaderFile(reader io.Reader, path string, isImport bool) *readerFile {
+	return &readerFile{
+		reader:   reader,
+		path:     path,
+		name:     filepath.Base(path),
+		isImport: isImport,
+	}
+}
+
+func (f *readerFile) Name() string {
+	return f.name
+}
+
+func (f *readerFile) Reader() (io.ReadCloser, error) {
+	return io.NopCloser(f.reader), nil
+}
+
+func (f *readerFile) IsApp() bool {
+	return !f.isImport
+}
+
+func (f *readerFile) IsImport() bool {
 	return f.isImport
 }
 

--- a/fs/filesystem.go
+++ b/fs/filesystem.go
@@ -43,7 +43,12 @@ func (f *localFile) IsImport() bool {
 	return f.isImport
 }
 
-func NewReaderFile(reader io.Reader, path string, isImport bool) *readerFile {
+// NewFileFromReader creates a new readerFile for provided io.Reader
+// with the given path and isImport flag. readerFile is an implementation of core.File
+// which is used to represent a file in the Code analysis framework
+//
+// This is required when you want to analyze a standalone file eg. an artifact file
+func NewFileFromReader(reader io.Reader, path string, isImport bool) *readerFile {
 	return &readerFile{
 		reader:   reader,
 		path:     path,

--- a/lang/factory.go
+++ b/lang/factory.go
@@ -2,6 +2,8 @@ package lang
 
 import (
 	"fmt"
+	"path/filepath"
+	"slices"
 
 	"github.com/safedep/code/core"
 )
@@ -21,4 +23,20 @@ func GetLanguage(name string) (core.Language, error) {
 	}
 
 	return nil, fmt.Errorf("language not found: %s", name)
+}
+
+func ResolveLanguage(filePath string) (core.Language, error) {
+	extension := filepath.Ext(filePath)
+
+	for _, f := range languages {
+		l, err := f()
+		if err != nil {
+			return nil, err
+		}
+
+		if slices.Contains(l.Meta().SourceFileExtensions, extension) {
+			return l, nil
+		}
+	}
+	return nil, fmt.Errorf("language not found for file: %s", filePath)
 }

--- a/lang/factory.go
+++ b/lang/factory.go
@@ -25,18 +25,23 @@ func GetLanguage(name string) (core.Language, error) {
 	return nil, fmt.Errorf("language not found: %s", name)
 }
 
-func ResolveLanguage(filePath string) (core.Language, error) {
+// ResolveLanguageFromPath resolves the programming language from the
+// filePath and returns the core.Language and a boolean indicating if the
+// language implementation exists for the specified file extension in filePath.
+//
+// It returns nil, false if the file extension is not supported by any implemented language.
+func ResolveLanguageFromPath(filePath string) (core.Language, bool) {
 	extension := filepath.Ext(filePath)
 
 	for _, f := range languages {
 		l, err := f()
 		if err != nil {
-			return nil, err
+			return nil, false
 		}
 
 		if slices.Contains(l.Meta().SourceFileExtensions, extension) {
-			return l, nil
+			return l, true
 		}
 	}
-	return nil, fmt.Errorf("language not found for file: %s", filePath)
+	return nil, false
 }

--- a/lang/factory_test.go
+++ b/lang/factory_test.go
@@ -1,0 +1,48 @@
+package lang
+
+import (
+	"testing"
+
+	"github.com/safedep/code/core"
+	"github.com/stretchr/testify/assert"
+)
+
+var resolveLanguageTestcases = []struct {
+	filePath             string
+	exists               bool
+	expectedLanguageCode core.LanguageCode
+}{
+	{filePath: "test.py", exists: true, expectedLanguageCode: core.LanguageCodePython},
+	{filePath: "test.js", exists: true, expectedLanguageCode: core.LanguageCodeJavascript},
+	{filePath: "test.cjs", exists: true, expectedLanguageCode: core.LanguageCodeJavascript},
+	{filePath: "test.mjs", exists: true, expectedLanguageCode: core.LanguageCodeJavascript},
+	{
+		filePath:             "test.go",
+		exists:               false,
+		expectedLanguageCode: "",
+	},
+	{
+		filePath:             "README.md",
+		exists:               false,
+		expectedLanguageCode: "",
+	},
+	{
+		filePath:             "withoutextension",
+		exists:               false,
+		expectedLanguageCode: "",
+	},
+}
+
+func TestResolveLanguage(t *testing.T) {
+	t.Run("ResolveLanguage", func(t *testing.T) {
+		for _, testcase := range resolveLanguageTestcases {
+			l, exists := ResolveLanguageFromPath(testcase.filePath)
+			assert.Equal(t, testcase.exists, exists)
+			if testcase.exists {
+				assert.Equal(t, testcase.expectedLanguageCode, l.Meta().Code)
+			} else {
+				assert.Nil(t, l)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Primarily, I've introduced another `core.File` implementation - `readerFile` (can be renamed to "artifactFile" / "standaloneFile" / any suggestions ?)
This allows using `ArtifactFile` to be used with already available plugin APIs

This can be used in malysis in place of [static.go#L201](https://github.com/safedep/malysis/blob/1a2fb87d936f369bc6b51d402889282f7afd3bc0/workflow/workflows/static.go#L201) like -

```golang
lang, _ := lang.ResolveLanguageFromPath(af.Name)
artifactParser, err := parser.NewParser(lang)
var readerFile core.File = fs.NewFileFromReader(af.Reader, af.Name, false)
parseTree, _ := artifactParser.Parse(ctx, readerFile)

var buf []byte
stripcommentsPlugin := stripcomments.NewStripCommentsPlugin(func(ctx context.Context, scpd *stripcomments.StripCommentsPluginData) error {
  scpd.Reader.Read(buf)
  return nil
})

if slices.Contains(stripcommentsPlugin.SupportedLanguages(), lang.Meta().Code) {
  stripcommentsPlugin.AnalyzeTree(ctx, parseTree)
} else {
  buf, err = io.ReadAll(io.LimitReader(af.Reader, readLimit))
}

```

Maybe, we can also have a util function for reusability, created at malysis level, which accepts an artifactFile and returns a `io.Reader` (reader from `StripCommentsPluginData` or the default one in case of unsupported lang)

